### PR TITLE
fix hlines in BarGraph.set_data(): sort descending

### DIFF
--- a/urwid/graphics.py
+++ b/urwid/graphics.py
@@ -304,6 +304,7 @@ class BarGraph(Widget):
         if hlines is not None:
             hlines = hlines[:]  # shallow copy
             hlines.sort()
+            hlines.reverse()
         self.data = bardata, top, hlines
         self._invalidate()
 


### PR DESCRIPTION
Passing multiple hlines in BarGraph.set_data() made urwid throw an exception. This fixes it (issue #66).
