### PR TITLE
Add equality operators to AttrSpec

### DIFF
--- a/urwid/display_common.py
+++ b/urwid/display_common.py
@@ -647,9 +647,7 @@ class AttrSpec(object):
             return vals + _COLOR_VALUES_256[self.background_number]
 
     def __eq__(self, other):
-        return isinstance(other, AttrSpec) \
-            and self.foreground == other.foreground \
-            and self.background == other.background
+        return isinstance(other, AttrSpec) and self._value == other._value
 
     def __ne__(self, other):
         return not self == other

--- a/urwid/display_common.py
+++ b/urwid/display_common.py
@@ -646,6 +646,12 @@ class AttrSpec(object):
         else:
             return vals + _COLOR_VALUES_256[self.background_number]
 
+    def __eq__(self, other):
+        return self.foreground == other.foreground and \
+               self.background == other.background
+
+    def __ne__(self, other):
+        return not self == other
 
 
 class RealTerminal(object):

--- a/urwid/display_common.py
+++ b/urwid/display_common.py
@@ -647,11 +647,14 @@ class AttrSpec(object):
             return vals + _COLOR_VALUES_256[self.background_number]
 
     def __eq__(self, other):
-        return self.foreground == other.foreground and \
-               self.background == other.background
+        return isinstance(other, AttrSpec) \
+            and self.foreground == other.foreground \
+            and self.background == other.background
 
     def __ne__(self, other):
         return not self == other
+
+    __hash__ = object.__hash__
 
 
 class RealTerminal(object):


### PR DESCRIPTION
By adding `__eq__` and `__ne__` methods to `AttrSpec`, we can now check if two objects have the same colors or not.

`__hash__` is necessary to keep AttrSpec hashable.