### PR TITLE
Restore terminal screen control on exception

### DIFF
--- a/urwid/main_loop.py
+++ b/urwid/main_loop.py
@@ -372,7 +372,11 @@ class MainLoop(object):
             finally:
                 self.screen.stop()
 
-        self.event_loop.run()
+        try:
+            self.event_loop.run()
+        except Exception as e:
+            self.screen.stop() # clean up screen control
+            raise e
         self.stop()
 
     def _update(self, keys, raw):


### PR DESCRIPTION
Solves issue for me (and I think others) where an exception in the eventloop caused the terminal session to be unresponsive after program crash. After crash user input (typing) would no longer be visible in terminal and scrolling and text selection would not function.

This slight tweak makes sure on unexpected exception in event_loop the screen control is released properly. 