### PR TITLE
Add bracketed paste mode escape sequences

### DIFF
--- a/urwid/escape.py
+++ b/urwid/escape.py
@@ -88,6 +88,8 @@ input_sequences = [
 
     ('[Z','shift tab'),
     ('On', '.'),
+
+    ('[200~', 'begin paste'), ('[201~', 'end paste'),
 ] + [
     (prefix + letter, modifier + key)
     for prefix, modifier in zip('O[', ('meta ', 'shift '))


### PR DESCRIPTION
Add [bracketed paste mode](https://cirw.in/blog/bracketed-paste) escape sequences to `escape.py` so urwid can pass these sequences to applications as "begin paste" and "end paste" keys.