### PR TITLE
fix for #127 Added a \r for the screen to be properly restored after …

### DIFF
--- a/urwid/raw_display.py
+++ b/urwid/raw_display.py
@@ -250,7 +250,8 @@ class Screen(BaseScreen, RealTerminal):
             self._attrspec_to_escape(AttrSpec('',''))
             + escape.SI
             + move_cursor
-            + escape.SHOW_CURSOR)
+            + escape.SHOW_CURSOR
+            + "\r")
 
         if self._old_signal_keys:
             self.tty_signal_keys(*(self._old_signal_keys + (fd,)))


### PR DESCRIPTION
…screen.stop()