### PR TITLE
A better fix for #127 and #60, added self.flush() instead of return

### DIFF
--- a/urwid/raw_display.py
+++ b/urwid/raw_display.py
@@ -250,8 +250,8 @@ class Screen(BaseScreen, RealTerminal):
             self._attrspec_to_escape(AttrSpec('',''))
             + escape.SI
             + move_cursor
-            + escape.SHOW_CURSOR
-            + "\r")
+            + escape.SHOW_CURSOR)
+        self.flush()
 
         if self._old_signal_keys:
             self.tty_signal_keys(*(self._old_signal_keys + (fd,)))


### PR DESCRIPTION
This works for my issue in #127 and @asmeurer reported it worked with his issue in #60.