### PR TITLE
urwid/widget.py: Edit: Do not crash on ISO-8859-15 with non utf-8 locale

### DIFF
--- a/urwid/widget.py
+++ b/urwid/widget.py
@@ -32,6 +32,8 @@ from urwid.command_map import (command_map, CURSOR_LEFT, CURSOR_RIGHT,
     CURSOR_UP, CURSOR_DOWN, CURSOR_MAX_LEFT, CURSOR_MAX_RIGHT)
 from urwid.split_repr import split_repr, remove_defaults, python3_repr
 
+import sys
+
 
 # define some names for these constants to avoid misspellings in the source
 # and to document the constant strings we are using
@@ -1412,7 +1414,7 @@ class Edit(Text):
             return text
         if tu:
             return text.encode('ascii') # follow python2's implicit conversion
-        return text.decode('ascii')
+        return text.decode(sys.stdin.encoding)
 
     def insert_text_result(self, text):
         """


### PR DESCRIPTION
On non utf-8 terminals 127 ascii is assumed as input encoding. For extended
ascii locales such as de_DE@euro, de_DE, en_US, fr_FR and so on this is wrong.
Python provides the correct input encoding of a terminal in the library
function sys.stdin.encoding which should be used instead.

Howto reproduce the bug:

(x1) [~] locale
LANG=C
LANGUAGE=en_US:en
LC_CTYPE=de_DE@euro
LC_NUMERIC="C"
LC_TIME="C"
LC_COLLATE="C"
LC_MONETARY="C"
LC_MESSAGES="C"
LC_PAPER="C"
LC_NAME="C"
LC_ADDRESS="C"
LC_TELEPHONE="C"
LC_MEASUREMENT="C"
LC_IDENTIFICATION="C"
LC_ALL=

(x1) [~] cat test.py
import urwid

def exit_on_q(key):
    if key in ('q', 'Q'):
        raise urwid.ExitMainLoop()

class QuestionBox(urwid.Filler):
    def keypress(self, size, key):
        if key != 'enter':
            return super(QuestionBox, self).keypress(size, key)
        self.original_widget = urwid.Text(
            u"Nice to meet you,\n%s.\n\nPress Q to exit." %
            edit.edit_text)

edit = urwid.Edit(u"What is your name?\n")
fill = QuestionBox(edit)
loop = urwid.MainLoop(fill, unhandled_input=exit_on_q)
loop.run()

(x1) [~] python test.py
Traceback (most recent call last):
  File "test.py", line 18, in <module>
    loop.run()
  File "/usr/lib/python2.7/dist-packages/urwid/main_loop.py", line 274, in run
    self.screen.run_wrapper(self._run)
  File "/usr/lib/python2.7/dist-packages/urwid/raw_display.py", line 268, in run_wrapper
    return fn()
  File "/usr/lib/python2.7/dist-packages/urwid/main_loop.py", line 339, in _run
    self.event_loop.run()
  File "/usr/lib/python2.7/dist-packages/urwid/main_loop.py", line 669, in run
    self._loop()
  File "/usr/lib/python2.7/dist-packages/urwid/main_loop.py", line 706, in _loop
    self._watch_files[fd]()
  File "/usr/lib/python2.7/dist-packages/urwid/main_loop.py", line 390, in _update
    self.process_input(keys)
  File "/usr/lib/python2.7/dist-packages/urwid/main_loop.py", line 490, in process_input
    k = self._topmost_widget.keypress(self.screen_size, k)
  File "test.py", line 10, in keypress
    return super(QuestionBox, self).keypress(size, key)
  File "/usr/lib/python2.7/dist-packages/urwid/decoration.py", line 836, in keypress
    return self._original_widget.keypress((maxcol,), key)
  File "/usr/lib/python2.7/dist-packages/urwid/widget.py", line 1474, in keypress
    self.insert_text(key)
  File "/usr/lib/python2.7/dist-packages/urwid/widget.py", line 1398, in insert_text
    text = self._normalize_to_caption(text)
  File "/usr/lib/python2.7/dist-packages/urwid/widget.py", line 1415, in _normalize_to_caption
    return text.decode('ascii')
UnicodeDecodeError: 'ascii' codec can't decode byte 0xfc in position 0: ordinal not in range(128)