### PR TITLE
Reset screen to original state on any exception.

### DIFF
--- a/urwid/main_loop.py
+++ b/urwid/main_loop.py
@@ -374,9 +374,9 @@ class MainLoop(object):
 
         try:
             self.event_loop.run()
-        except Exception as e:
+        except:
             self.screen.stop() # clean up screen control
-            raise e
+            raise
         self.stop()
 
     def _update(self, keys, raw):


### PR DESCRIPTION
In MainLoop._run() we were running self.event_loop.run() in
an exception frame so that we could reset the screen in the
case of an unclean shutdown of the MainLoop. The catch specification
was "except Exception as e" but this doesn't include exceptions that
don't derive from Exception, like KeyboardInterrupt (i.e. Ctrl-C).
This change fixes that.